### PR TITLE
Add 'Save and Next Week' option and show notes in availability

### DIFF
--- a/frontend/src/app/availability/create/page.tsx
+++ b/frontend/src/app/availability/create/page.tsx
@@ -36,6 +36,7 @@ export default function CreateAvailabilityPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoadingAvailability, setIsLoadingAvailability] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [saveAndGoToNextWeek, setSaveAndGoToNextWeek] = useState(false);
 
   // Redirect if not authenticated
   useEffect(() => {
@@ -212,8 +213,15 @@ export default function CreateAvailabilityPage() {
 
       await api.updateMyWeekAvailability(updateData);
 
-      // Success! Redirect back to availability page
-      router.push("/availability");
+      // Check if we should go to next week or back to availability page
+      if (saveAndGoToNextWeek && selectedWeekIndex < 3) {
+        // Go to next week
+        setSelectedWeekIndex((prev) => prev + 1);
+        setSaveAndGoToNextWeek(false); // Reset checkbox
+      } else {
+        // Success! Redirect back to availability page
+        router.push("/availability");
+      }
     } catch (error: unknown) {
       console.error("Error saving availability:", error);
 
@@ -513,6 +521,29 @@ export default function CreateAvailabilityPage() {
                       </div>
                     </div>
                   ))}
+                </div>
+
+                {/* Save and Next Week Option */}
+                <div className="border-t border-gray-200/50 pt-6">
+                  <label className="flex items-center space-x-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={saveAndGoToNextWeek}
+                      onChange={(e) => setSaveAndGoToNextWeek(e.target.checked)}
+                      disabled={selectedWeekIndex >= 3}
+                      className="h-4 w-4 text-[#d5896f] border-gray-300 rounded focus:ring-[#d5896f] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
+                    <span 
+                      className={`text-sm font-medium ${selectedWeekIndex >= 3 ? 'text-gray-400' : 'text-gray-700'}`}
+                    >
+                      Opslaan en naar volgende week
+                    </span>
+                  </label>
+                  {selectedWeekIndex >= 3 && (
+                    <p className="text-xs text-gray-500 mt-1 ml-7">
+                      Je kunt maximaal 4 weken vooruit plannen
+                    </p>
+                  )}
                 </div>
 
                 {/* Form Actions */}

--- a/frontend/src/app/availability/page.tsx
+++ b/frontend/src/app/availability/page.tsx
@@ -466,56 +466,87 @@ export default function AvailabilityPage() {
 
                 <div className="space-y-4">
                   {weekAvailabilities.map(
-                    (week: WeekAvailability, weekIndex: number) => (
-                      <div
-                        key={weekIndex}
-                        className={`p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer hover:bg-gray-50 ${
-                          weekIndex === currentWeekIndex
-                            ? "border-blue-300 bg-blue-50"
-                            : "border-gray-200 bg-white"
-                        }`}
-                        onClick={() => setCurrentWeekIndex(weekIndex)}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div>
-                            <h4 className="font-semibold text-gray-900">
-                              Week {getWeekNumber(week.weekStart)}
-                            </h4>
-                            <p className="text-sm text-gray-600">
-                              {formatWeekRange(week.weekStart)}
-                            </p>
+                    (week: WeekAvailability, weekIndex: number) => {
+                      // Filter days that have notes
+                      const daysWithNotes = week.days.filter(day => day.notes && day.notes.trim() !== '');
+                      
+                      return (
+                        <div
+                          key={weekIndex}
+                          className={`p-4 rounded-xl border-2 transition-all duration-200 cursor-pointer hover:bg-gray-50 ${
+                            weekIndex === currentWeekIndex
+                              ? "border-blue-300 bg-blue-50"
+                              : "border-gray-200 bg-white"
+                          }`}
+                          onClick={() => setCurrentWeekIndex(weekIndex)}
+                        >
+                          <div className="flex items-center justify-between">
+                            <div>
+                              <h4 className="font-semibold text-gray-900">
+                                Week {getWeekNumber(week.weekStart)}
+                              </h4>
+                              <p className="text-sm text-gray-600">
+                                {formatWeekRange(week.weekStart)}
+                              </p>
+                            </div>
+
+                            <div className="flex space-x-1">
+                              {week.days.map(
+                                (day: DayAvailability, dayIndex: number) => (
+                                  <div
+                                    key={dayIndex}
+                                    className={`w-6 h-6 rounded-full border-2 flex items-center justify-center ${
+                                      day.isAvailable === true
+                                        ? "bg-green-100 border-green-300"
+                                        : day.isAvailable === false
+                                          ? "bg-red-100 border-red-300"
+                                          : "bg-gray-100 border-gray-300"
+                                    }`}
+                                    title={`${day.dayOfWeek}: ${getAvailabilityText(day.isAvailable)}`}
+                                  >
+                                    {day.isAvailable === true && (
+                                      <CheckCircle className="h-3 w-3 text-green-600" />
+                                    )}
+                                    {day.isAvailable === false && (
+                                      <XCircle className="h-3 w-3 text-red-600" />
+                                    )}
+                                    {day.isAvailable === null && (
+                                      <Minus className="h-3 w-3 text-gray-400" />
+                                    )}
+                                  </div>
+                                ),
+                              )}
+                            </div>
                           </div>
 
-                          <div className="flex space-x-1">
-                            {week.days.map(
-                              (day: DayAvailability, dayIndex: number) => (
-                                <div
-                                  key={dayIndex}
-                                  className={`w-6 h-6 rounded-full border-2 flex items-center justify-center ${
-                                    day.isAvailable === true
-                                      ? "bg-green-100 border-green-300"
-                                      : day.isAvailable === false
-                                        ? "bg-red-100 border-red-300"
-                                        : "bg-gray-100 border-gray-300"
-                                  }`}
-                                  title={`${day.dayOfWeek}: ${getAvailabilityText(day.isAvailable)}`}
-                                >
-                                  {day.isAvailable === true && (
-                                    <CheckCircle className="h-3 w-3 text-green-600" />
-                                  )}
-                                  {day.isAvailable === false && (
-                                    <XCircle className="h-3 w-3 text-red-600" />
-                                  )}
-                                  {day.isAvailable === null && (
-                                    <Minus className="h-3 w-3 text-gray-400" />
-                                  )}
-                                </div>
-                              ),
-                            )}
-                          </div>
+                          {/* Display notes if any day has notes */}
+                          {daysWithNotes.length > 0 && (
+                            <div className="mt-4 pt-4 border-t border-gray-200">
+                              <h5 className="text-sm font-medium text-gray-700 mb-3">
+                                Notities:
+                              </h5>
+                              <div className="space-y-2">
+                                {daysWithNotes.map((day, index) => (
+                                  <div
+                                    key={index}
+                                    className="bg-gray-50 rounded-lg p-3 border border-gray-200"
+                                  >
+                                    <div className="flex items-start space-x-2">
+                                      <span className="text-sm font-medium text-gray-700 capitalize min-w-[80px]">
+                                        {day.dayOfWeek}:
+                                      </span>
+                                      <span className="text-sm text-gray-600 flex-1">
+                                        {day.notes}
+                                      </span>
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
                         </div>
-                      </div>
-                    ),
+                      );
+                    }
                   )}
                 </div>
               </div>


### PR DESCRIPTION
This pull request introduces enhancements to the `CreateAvailabilityPage` and `AvailabilityPage` components in the frontend application. The changes focus on improving user experience by adding new functionality for navigating between weeks and displaying notes associated with availability days.

### Enhancements to `CreateAvailabilityPage`:

* Added a checkbox option to allow users to save their availability and automatically proceed to the next week. This includes logic to handle navigation and reset the checkbox state. (`frontend/src/app/availability/create/page.tsx`, [[1]](diffhunk://#diff-cf0ae69de8f4b730b2932df427ce63b50d58a03f306dd2c95710ff0060e7b8c6R39) [[2]](diffhunk://#diff-cf0ae69de8f4b730b2932df427ce63b50d58a03f306dd2c95710ff0060e7b8c6R216-R224)
* Implemented UI elements for the "Save and Next Week" option, including a disabled state and explanatory text when the maximum week limit is reached. (`frontend/src/app/availability/create/page.tsx`, [frontend/src/app/availability/create/page.tsxR526-R548](diffhunk://#diff-cf0ae69de8f4b730b2932df427ce63b50d58a03f306dd2c95710ff0060e7b8c6R526-R548))

### Enhancements to `AvailabilityPage`:

* Added functionality to filter and display days that have associated notes. (`frontend/src/app/availability/page.tsx`, [frontend/src/app/availability/page.tsxL469-R473](diffhunk://#diff-99afb53d2e29dccc55a42eb7b2be2894f9aabd59557161f332c3ca5def1ab42eL469-R473))
* Introduced a section to display notes for days with availability, enhancing visibility of additional information. (`frontend/src/app/availability/page.tsx`, [frontend/src/app/availability/page.tsxR521-R549](diffhunk://#diff-99afb53d2e29dccc55a42eb7b2be2894f9aabd59557161f332c3ca5def1ab42eR521-R549))