### PR TITLE
Add IsStandby to shifts and update related logic

### DIFF
--- a/backend/DTOs/ShiftDto.cs
+++ b/backend/DTOs/ShiftDto.cs
@@ -28,6 +28,11 @@ public class CreateShiftDto
     public bool IsOpenEnded { get; set; } = false;
 
     /// <summary>
+    /// Indicates if this is a standby shift (employee doesn't necessarily have to come to work)
+    /// </summary>
+    public bool IsStandby { get; set; } = false;
+
+    /// <summary>
     /// Optional notes for the shift
     /// </summary>
     [MaxLength(500, ErrorMessage = "Notes cannot exceed 500 characters")]
@@ -59,6 +64,11 @@ public class UpdateShiftDto
     public bool IsOpenEnded { get; set; } = false;
 
     /// <summary>
+    /// Indicates if this is a standby shift (employee doesn't necessarily have to come to work)
+    /// </summary>
+    public bool IsStandby { get; set; } = false;
+
+    /// <summary>
     /// Optional notes for the shift
     /// </summary>
     [MaxLength(500, ErrorMessage = "Notes cannot exceed 500 characters")]
@@ -76,6 +86,7 @@ public class ShiftResponseDto
     public ShiftType ShiftType { get; set; }
     public string ShiftTypeName { get; set; } = string.Empty;
     public bool IsOpenEnded { get; set; }
+    public bool IsStandby { get; set; }
     public string? Notes { get; set; }
     public string TimeRange { get; set; } = string.Empty;
     public double? DurationInHours { get; set; }
@@ -106,4 +117,5 @@ public class ShiftFilterDto
     public int? EmployeeId { get; set; }
     public ShiftType? ShiftType { get; set; }
     public bool? IsOpenEnded { get; set; }
+    public bool? IsStandby { get; set; }
 }

--- a/backend/Migrations/20250707151818_AddIsStandbyToShifts.Designer.cs
+++ b/backend/Migrations/20250707151818_AddIsStandbyToShifts.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.Data;
@@ -11,9 +12,11 @@ using backend.Data;
 namespace backend.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250707151818_AddIsStandbyToShifts")]
+    partial class AddIsStandbyToShifts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20250707151818_AddIsStandbyToShifts.cs
+++ b/backend/Migrations/20250707151818_AddIsStandbyToShifts.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsStandbyToShifts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Availability_EmployeeId_Date",
+                table: "Availabilities");
+
+            migrationBuilder.DeleteData(
+                table: "Employees",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Availability_EmployeeId",
+                table: "Availabilities",
+                newName: "IX_Availabilities_EmployeeId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Availability_Date",
+                table: "Availabilities",
+                newName: "IX_Availabilities_Date");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsStandby",
+                table: "Shifts",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Shifts_IsStandby",
+                table: "Shifts",
+                column: "IsStandby");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Availabilities_EmployeeId_Date",
+                table: "Availabilities",
+                columns: new[] { "EmployeeId", "Date" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Shifts_IsStandby",
+                table: "Shifts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Availabilities_EmployeeId_Date",
+                table: "Availabilities");
+
+            migrationBuilder.DropColumn(
+                name: "IsStandby",
+                table: "Shifts");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Availabilities_EmployeeId",
+                table: "Availabilities",
+                newName: "IX_Availability_EmployeeId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Availabilities_Date",
+                table: "Availabilities",
+                newName: "IX_Availability_Date");
+
+            migrationBuilder.InsertData(
+                table: "Employees",
+                columns: new[] { "Id", "BirthDate", "CreatedAt", "FirstName", "HireDate", "LastName", "PasswordHash", "Role", "UpdatedAt", "Username" },
+                values: new object[] { 1, new DateTime(1990, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), new DateTime(2025, 7, 2, 13, 38, 11, 264, DateTimeKind.Utc).AddTicks(5133), "Admin", new DateTime(2025, 7, 2, 13, 38, 11, 264, DateTimeKind.Utc).AddTicks(5133), "User", "$2a$11$5KhE6q2RjqNXEy8m0KW1kOgUdDcfBugEmHjHXf2h4RnxXclCJKF5q", 2, new DateTime(2025, 7, 2, 13, 38, 11, 264, DateTimeKind.Utc).AddTicks(5133), "admin" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Availability_EmployeeId_Date",
+                table: "Availabilities",
+                columns: new[] { "EmployeeId", "Date" },
+                unique: true);
+        }
+    }
+}

--- a/backend/Models/Availability.cs
+++ b/backend/Models/Availability.cs
@@ -16,7 +16,7 @@ public class Availability
     public bool IsAvailable { get; set; }
 
     /// <summary>
-    /// Optional notes for manager (max 500 characters)
+    /// Optional notes for availability (max 500 characters)
     /// </summary>
     [MaxLength(500, ErrorMessage = "Notes cannot exceed 500 characters")]
     public string? Notes { get; set; }

--- a/backend/Models/Shift.cs
+++ b/backend/Models/Shift.cs
@@ -29,6 +29,11 @@ public class Shift
     public bool IsOpenEnded { get; set; } = false;
 
     /// <summary>
+    /// Indicates if this is a standby shift (employee doesn't necessarily have to come to work)
+    /// </summary>
+    public bool IsStandby { get; set; } = false;
+
+    /// <summary>
     /// Optional notes for the shift
     /// </summary>
     [MaxLength(500, ErrorMessage = "Notes cannot exceed 500 characters")]


### PR DESCRIPTION
Introduces the IsStandby property to the Shift model, DTOs, and database schema, allowing shifts to be marked as standby. Updates ShiftService and ShiftController to support filtering and handling of standby shifts, including overlap logic. Refactors indexes and cleans up entity configuration for Availabilities and TimeOffRequests. Removes default admin seeding and updates migration files accordingly.